### PR TITLE
Reviewer suggestions for ReScience article

### DIFF
--- a/article/content.tex
+++ b/article/content.tex
@@ -28,15 +28,15 @@ Replicating a classic study and model like this one is important for many reason
 ensuring that they can still be reproduced;
 2) we can provide a publicly available and reproducible version of the codes that recreate
 the model.
-We were able to successfully replicate all the figures in the original article using
+We were able to successfully replicate all figures in the original article using
 \textit{Julia v1.3.1}.
-All the code used to replicate the original model is available alongside this article
+All code used to replicate the original model is available alongside this article
 (\url{https://github.com/BIO6032/2019_replication_HastingsPowell_1991}).
 
 \section{Methods}
 
 The model formulation used in this paper is the same as in the original
-publication. \citeauthor{hastings1991} used a 14 parameters model to represent the three-species
+publication. \citeauthor{hastings1991} used a 14 parameter model to represent the three-species
 food chain, with $X$, $Y$, and $Z$ as the numbers of the species at the lowest level of
 the food chain, of the species that preys upon $X$, and of the species that preys upon
 $Y$, respectively.
@@ -146,7 +146,7 @@ dynamics. Moreover, \citeauthor{hastings1991} mention removing points resulting 
 secondary local maxima, but do not provide details on how to identify these points.
 Hence, we adopted the following method:
 1) we selected the 1000 last solutions for our system between time steps 1 and 10 000, in
-order to eliminate transient behaviour;
+order to eliminate transient behaviour; %Reviewer comment: This is unclear to me. Do you mean time steps 9000-10000? Please clarify.
 2) we selected the values that were greater than both their preceding and following
 values, which identified local maxima only;
 and 3) we only kept values that were greater than a given threshold of the cycle's maximal
@@ -217,7 +217,7 @@ Indeed, $x$ varies approximately from 0.2 to 1.0, $y$ from 0.0 to 0.4, and $z$ f
 
 Second, the time series of $x$ from $t = 0$ to $500$ supports the chaotic behaviour of the
 system, with slightly different initial conditions leading to increasingly different
-trajectories(\autoref{fig:fig3}). The values themselves are almost identical to \citeauthor{hastings1991}'s
+trajectories (\autoref{fig:fig3}). The values themselves are almost identical to \citeauthor{hastings1991}'s
 until $t \approx 250$, at which point they start to diverge, but this behaviour was to be
 expected without the exact same initial conditions.
 
@@ -236,7 +236,7 @@ confirm that chaos occurs for values other than $b_2$ = 2.0. Chaos is apparent f
 smaller or greater values.
 However, while \citeauthor{hastings1991} reported that chaos was more likely for greater values of
 $b_2$, our results highlight that $z$ instead converges to a single value and starts to
-crash past $b_2$ = 2.35.
+crash past $b_2$ = 2.35. %Reviewer comment: Please clarify what you mean by "crash" here. e.g. "starts to rapidly approach zero"
 
 Lastly, although \citeauthor{hastings1991} did not specify the equation of the plane that
 crosses the trajectories of the phase plot at its "handle", we were able to accurately
@@ -293,7 +293,8 @@ at $b_1$ = 3.1.
 
 While we also found chaos for values of $b_2$ other than the default one of 2.0, both
 smaller or greater, we do not totally agree with \citeauthor{hastings1991} that "chaos is more
-likely for larger values of $b_2$". As \autoref{fig:figS1}, chaos can be quite likely for both
+likely for larger values of $b_2$". As \autoref{fig:figS1} shows %Reviewer comment: missing verb?
+, chaos can be quite likely for both
 smaller or larger values.
 We find important to note, however, that at a certain value of $b_2$, $z$ converges and
 starts to crash, thus exhibiting non chaotic behaviour within a given range of $b_1$
@@ -311,7 +312,7 @@ Although we were able to precisely replicate the Poincaré sections for $b_1$ = 
 For $b_1$ = 3.0 (\autoref{fig:figS1}b), it lacked some points of the phase plots and included
 others that were closed yet non-coincident with the plane.
 For $b_1$ = 6.0 (\autoref{fig:figS1}d), the discrepancy was more obvious, and might be due to the
-more chaotic behaviour of the system under this parameter, observed for example from the
+more chaotic behaviour of the system under this parameter value, observed for example from the
 larger width of its "handle" (compare axis intervals of \autoref{fig:figS1} a,c).
 
 We have succeeded in replicating \citeauthor{hastings1991}'s model and its main findings, as our
@@ -319,12 +320,12 @@ results confirm chaos arising in a three species food chain in continuous time.
 In general, the model, including its equations and parameters, was well described by the
 authors. The most significant obstacles to reproducibility in \citeauthor{hastings1991}'s paper
 were the absence of the values of the initial conditions, which have a huge impact on a
-chaotic system, and the insufficient description of certain methods.
+chaotic system, and the insufficient description of certain methods. %Reviewer comment: Be explicit here about what was insufficiently described. E.g. the numerical integration methods.
 Consequently, there are slight differences between our results and theirs.
 Furthermore, since we tried to keep our implementation as close as possible to the
 original one, some steps did rely on arbitrary thresholds (for instance for the primary
 local maxima or the boundaries of the Poincaré sections and maps).
-Hence, our replication is somewhat not very flexible and possibly could not be applied to
+Hence, our replication is somewhat inflexible and possibly could not be applied to
 a broader range of parameter values.
 We suggest that an interesting step forward would be to train machine-learning algorithms,
 such as neural networks, to identify chaotic behaviour and its boundaries, in order to

--- a/code/figure4.jl
+++ b/code/figure4.jl
@@ -1,5 +1,6 @@
 ### Hastings & Powell 1991
 ## Reproducing figure 4
+using LaTeXStrings
 
 ### Figure 4 (Bifurcation diagram)
 
@@ -63,7 +64,7 @@ pts_maxloc = points_maxloc[points_maxloc[:,2] .> 0.00, :]
 fig4a = scatter(pts_maxloc[:, 1], pts_maxloc[:, 2],
                 markersize = 2, markeralpha = 0.5,
                 xlim = (2.2, 3.2), ylim = (9.5, 13.0),
-                xlabel = "b1", ylabel = "Zmax", legend = false,
+                xlabel = L"b_1", ylabel = L"z_{max}", legend = false,
                 grid = :none, c = :black, msw = 0.0, msc = :black,
                 title = "a", titleloc = :left
                 )
@@ -72,7 +73,7 @@ fig4b = scatter(pts_maxloc[:, 1], pts_maxloc[:, 2],
                 markersize = 2, markeralpha = 0.5, 
                 xlim = (3.0, 6.5), ylim = (3.0, 10.0),
                 xticks = 3.0:0.5:6.5, yticks = (3.0:1.0:10.0, string.(3.0:1.0:10.0)),
-                xlabel = "b1", ylabel = "Zmax", legend = false,
+                xlabel = L"b_1", ylabel = L"z_{max}", legend = false,
                 grid = :none, c = :black, msw = 0.0, msc = :black,
                 title = "b", titleloc = :left
                 )
@@ -81,7 +82,7 @@ fig4c = scatter(pts_maxloc[:, 1], pts_maxloc[:, 2],
                 markersize = 2, markeralpha = 0.5,
                 xlim = (2.25, 2.6), ylim = (11.4, 12.8),
                 xticks = 2.25:0.05:2.60, yticks = 11.1:0.2:12.8,
-                xlabel = "b1", ylabel = "Zmax", legend = false,
+                xlabel = L"b_1", ylabel = L"z_{max}", legend = false,
                 grid = :none, c = :black, msw = 0.0, msc = :black,
                 title = "c", titleloc = :left
                 )

--- a/code/figure5.jl
+++ b/code/figure5.jl
@@ -51,7 +51,7 @@ fig5a = plot(sol_x_b3[ind_xyz_b3], sol_y_b3[ind_xyz_b3],
              legend = false,
              seriestype = :scatter,
              xlabel = "x(n)", xlim = (xmin, xmax), xticks = xmin:0.01:xmax, xminorticks = 2,
-             ylabel = "x(n)", ylim = (ymin, ymax), yticks = ymin:0.01:ymax, yminorticks = 2,
+             ylabel = "y(n)", ylim = (ymin, ymax), yticks = ymin:0.01:ymax, yminorticks = 2,
              xgrid = :none, ygrid = :none,
              title = "A", titleloc = :left,
              c = :black, ms = 3)

--- a/code/figureS1.jl
+++ b/code/figureS1.jl
@@ -1,6 +1,6 @@
 ### Hastings & Powell 1991
 ## Examining behavior when varying b2 value
-
+using LaTeXStrings
 ### Figure S1 (Bifurcation diagram)
 
 ## Wrap in function
@@ -77,8 +77,8 @@ function b2_behavior(;b1val::Float64, b2low::Float64=1.5, b2up::Float64=3.2,out:
   # Plot results (bifurcation diagram)
   scatter(results[:,1], results[:,2],
           markersize = 1, c = :black,
-          xlabel = "b2", xlim = (b2low,b2up), xticks = b2low:0.25:b2up,
-          ylabel = "Zmax", yticks = (0.0:2.0:maximum(results[:, 2]), string.(0.0:2.0:maximum(results[:, 2]))),
+          xlabel = L"b_2", xlim = (b2low,b2up), xticks = b2low:0.25:b2up,
+          ylabel = L"z_{max}", yticks = (0.0:2.0:maximum(results[:, 2]), string.(0.0:2.0:maximum(results[:, 2]))),
           legend = false, grid = :none, framestyle = :box,
           guidefontsize = 10)
 end


### PR DESCRIPTION
Some suggested changes to the ReScience manuscript "[Re] Chaos in a Three-Species Food Chain".

https://github.com/BIO6032/2019_replication_HastingsPowell_1991/commit/ef8143f47f5e920cfda81594cb6ce7b993cf13a6 fixes a typo in the axis label of Fig. 5

https://github.com/BIO6032/2019_replication_HastingsPowell_1991/commit/4fbc7ae8cffd8f45a5c6c9d1e9fbe7cc8975f6e6 is a suggestion to use LaTeXStrings for proper subscripts in Figure labels

https://github.com/BIO6032/2019_replication_HastingsPowell_1991/commit/5013f87b9382a82cd6a35aa815603c3e852f7295 includes comments and minor edits to the manuscript. Comments that may need additional revision are prefixed with a LaTeX comment string `%Reviewer comment:`

Additional comments are provided in the review thread at https://github.com/ReScience/submissions/issues/15